### PR TITLE
Proposed refactor for LanguageManager / 'accessibility.screenreader' changes

### DIFF
--- a/apps/ftu/js/language.js
+++ b/apps/ftu/js/language.js
@@ -8,15 +8,25 @@ var LanguageManager = {
   init: function init() {
     this.buildLanguageList();
     document.getElementById('languages').addEventListener('change', this);
-    this.settings.addObserver('language.current',
-      function updateDefaultLayouts(event) {
-        // the 2nd parameter is to reset the current enabled layouts
-        KeyboardHelper.changeDefaultLayouts(event.settingValue, true);
-      });
     window.addEventListener('localized',
       this.localizedEventListener.bind(this));
-    this.settings.addObserver('accessibility.screenreader',
-      this.buildLanguageList.bind(this));
+
+    var onSettingChange = this._boundHandleSettingChange =
+      this.handleSettingChange.bind(this);
+    this.settings.addObserver('language.current', onSettingChange);
+    this.settings.addObserver('accessibility.screenreader', onSettingChange);
+  },
+
+  handleSettingChange: function(evt) {
+    switch (evt.settingName) {
+      case 'accessibility.screenreader':
+        this.buildLanguageList();
+        break;
+      case 'language.current':
+        // the 2nd parameter is to reset the current enabled layouts
+        KeyboardHelper.changeDefaultLayouts(evt.settingValue, true);
+        break;
+    }
   },
 
   handleEvent: function handleEvent(evt) {

--- a/apps/ftu/js/language.js
+++ b/apps/ftu/js/language.js
@@ -15,6 +15,8 @@ var LanguageManager = {
       });
     window.addEventListener('localized',
       this.localizedEventListener.bind(this));
+    this.settings.addObserver('accessibility.screenreader',
+      this.buildLanguageList.bind(this));
   },
 
   handleEvent: function handleEvent(evt) {

--- a/apps/settings/js/panels/languages/panel.js
+++ b/apps/settings/js/panels/languages/panel.js
@@ -3,6 +3,7 @@
 define(function(require) {
   var SettingsPanel = require('modules/settings_panel');
   var Languages = require('panels/languages/languages');
+  var SettingsListener = require('shared/settings_listener');
 
   return function ctor_languages_panel() {
     var languages = Languages();
@@ -14,11 +15,15 @@ define(function(require) {
         languages.buildList();
         languages.updateDateTime();
         window.addEventListener('localized', onLocalized);
+        Settings.mozSettings.addObserver(
+          'accessibility.screenreader', onAdditionalLanguagesChange);
         document.addEventListener(
           'additionallanguageschange', onAdditionalLanguagesChange);
       },
       onBeforeHide: function() {
         window.removeEventListener('localized', onLocalized);
+        Settings.mozSettings.removeObserver(
+          'accessibility.screenreader', onAdditionalLanguagesChange);
         document.removeEventListener(
           'additionallanguageschange', onAdditionalLanguagesChange);
       },

--- a/apps/system/js/accessibility.js
+++ b/apps/system/js/accessibility.js
@@ -1,5 +1,5 @@
 'use strict';
-/* global SettingsListener, LazyLoader, Service */
+/* global SettingsListener, LazyLoader, Service, SettingsHelper */
 /* global AccessibilityQuicknavMenu */
 
 (function(exports) {
@@ -51,6 +51,13 @@
     HINTS_TIMEOUT: 2000,
 
     /**
+     * If the current language is not supported by any synthesis voice, fall
+     * back to this language.
+     **/
+
+    FALLBACK_LANGUAGE: 'en-US',
+
+    /**
      * Current counter for button presses in short succession.
      * @type {Number}
      * @memberof Accessibility.prototype
@@ -85,6 +92,7 @@
       'accessibility.screenreader-rate': 0,
       'accessibility.screenreader-captions': false,
       'accessibility.screenreader-shade': false,
+      'accessibility.screenreader-fallback-lang': 'en-US',
       'accessibility.colors.enable': false,
       'accessibility.colors.invert': false,
       'accessibility.colors.grayscale': false,
@@ -145,6 +153,7 @@
                   SettingsListener.getSettingsLock().set({
                     'accessibility.screenreader-show-settings': true
                   });
+                  this.setToSupportedLanguage();
                 }
                 if (this.settings['accessibility.screenreader-shade']) {
                   this.toggleShade(aValue, !aValue);
@@ -227,6 +236,19 @@
         this.speak({ string: aEnable ? 'shadeToggleOn' : 'shadeToggleOff' },
           null, {enqueue: true});
       }
+    },
+
+    setToSupportedLanguage: function ar_setToSupportedLanguage() {
+      var settingsHelper = SettingsHelper('language.current');
+      var voices = this.speechSynthesizer.speech.getVoices();
+      var speechLangs = new Set([for (v of voices) v.lang.split('-')[0]]);
+
+      settingsHelper.get((value) => {
+        if (!speechLangs.has(value.split('-')[0])) {
+          settingsHelper.set(
+            this.settings['accessibility.screenreader-fallback-lang']);
+        }
+      });
     },
 
     /**

--- a/shared/js/language_list.js
+++ b/shared/js/language_list.js
@@ -93,6 +93,16 @@ exports.LanguageList = {
     }
   },
 
+  _removeWithNoSpeech: function(languages) {
+    var speechLangs = new Set(
+      [for (v of speechSynthesis.getVoices()) v.lang.split('-')[0]]);
+    for (var langName in languages) {
+      if (!speechLangs.has(langName.split('-')[0])) {
+        delete languages[langName];
+      }
+    }
+  },
+
   _copyObj: function(obj) {
     var copy = Object.create(null);
     for (var prop in obj) {
@@ -111,13 +121,18 @@ exports.LanguageList = {
       this._readSetting('deviceinfo.os'),
       this._readSetting('language.current'),
       this._readSetting('devtools.qps.enabled'),
+      this._readSetting('accessibility.screenreader'),
       navigator.mozApps.getAdditionalLanguages()
-    ]).then(function([langsFromFile, ver, current, qpsEnabled, addl]) {
-      var langs = this._copyObj(langsFromFile);
-      this._extendPseudo(langs, current, qpsEnabled);
-      this._extendAdditional(langs, this._parseVersion(ver), addl);
-      return [langs, current];
-    }.bind(this));
+    ]).then(
+      function([langsFromFile, ver, current, qpsEnabled, srEnabled, addl]) {
+        var langs = this._copyObj(langsFromFile);
+        this._extendPseudo(langs, current, qpsEnabled);
+        this._extendAdditional(langs, this._parseVersion(ver), addl);
+        if (srEnabled) {
+          this._removeWithNoSpeech(langs);
+        }
+        return [langs, current];
+      }.bind(this));
 
   },
 


### PR DESCRIPTION
Can we do something like this to refactor the settings observers? 
We'll still want a simple unit test added to ensure the settings is observed and buildLanguageList is called when it is updated
